### PR TITLE
Extract source address from os:env

### DIFF
--- a/src/tcp_metrics.erl
+++ b/src/tcp_metrics.erl
@@ -26,12 +26,18 @@ start_link() ->
 init(Parent) ->
     proc_lib:init_ack(Parent, {ok, self()}),
     ets:new(?TABLE, [set, {read_concurrency, true}, named_table]),
-    SourceAddress =
-        case application:get_env(tcp_metrics, source_address) of
-            {ok, X} -> X;
-            _ -> {0,0,0,0}
-        end,
-    loop(#state{source_address = SourceAddress}).
+    loop(#state{source_address = source_address()}).
+
+source_address() ->
+    case os:getenv("TCP_METRICS_SOURCE_ADDR") of
+        false ->
+            case application:get_env(tcp_metrics, source_address) of
+                {ok, X} -> X;
+                _ -> {0,0,0,0}
+            end;
+        SourceAddress ->
+            SourceAddress
+    end.
 
 
 %% lookup the estimated RTT in millisecs for an IP.


### PR DESCRIPTION
When working with containers and k8, providing the source address in the erlang env configuration files requires that we generate a new template per pod instance which is pretty problematic and goes against the grain/spirit of k8. It's significantly easier to to take it from the os' environment variable.

I can't think of significant or strong reasons to prefer one over the other if both are provided so I chose the os' env variable to take precedence quite arbitrarily.